### PR TITLE
Avoid Qt crashes in getContext

### DIFF
--- a/qml/components/NeonClock.qml
+++ b/qml/components/NeonClock.qml
@@ -5,6 +5,7 @@ Canvas {
     anchors.centerIn: parent
     property bool coverMode: false
     property real drawUnit: width / (coverMode ? 32 : 50)
+    readonly property bool canPaint: coverMode || Qt.application.active
 
     property var now
 
@@ -24,6 +25,8 @@ Canvas {
     renderStrategy: Canvas.Threaded
     renderTarget: Canvas.FramebufferObject
     onPaint: {
+        if (!canPaint) return
+
         now = new Date()
         ms = now.getMilliseconds()
         s = now.getSeconds()


### PR DESCRIPTION
Or at least significantly reduce the probability of those to happen. So far I haven't seen a single crash with these changes applied.

The one in NeonClock.qml is the important one, the change in MainPage.qml doesn't really make much of a difference.